### PR TITLE
Review fixes for het() function

### DIFF
--- a/bin/pique-input
+++ b/bin/pique-input
@@ -972,12 +972,15 @@ sub maf {
 
  Usage       : het()
  Parameters  : $prefix = input/output prefix for PLINK
-	     : $min = minimum F coefficient
+             : $min = minimum F inbreeding coefficient (suggested: 0.999 for highly
+             :        inbred lines; use lower values e.g. 0.5 for landrace populations)
  Returns     : null
- Description : Remove samples with high heterozygosity estimated by F (Method of Moments)
- Files       : $prefix.het = heterozygosity estimates
-	     : $prefix.hid = list of samples with low heterozygosity
-	     : $prefix.ped = filtered .ped file
+ Description : Remove samples with excess heterozygosity estimated by F (Method of Moments).
+             : Samples with F below $min are removed. Note: not appropriate for polyploid
+             : species (e.g. hexaploid wheat) where --het results are unreliable.
+ Files       : $prefix.het = per-sample heterozygosity estimates from PLINK
+             : $prefix.hid = FID/IID list of samples flagged for removal (F < $min)
+             : $prefix.ped = filtered .ped file
 
 =cut
 
@@ -989,9 +992,9 @@ sub het {
         print "Calculating heterozygosity...\n";
     }
     plink("--het --pedmap $prefix --out $prefix");
-    run("awk '\$6 < $min {print \$1\" \"\$2}' $prefix.het > $prefix.hid");
+    run("awk 'NR > 1 && \$6 < $min {print \$1\" \"\$2}' $prefix.het > $prefix.hid");
     plink("--pedmap $prefix --remove $prefix.hid --make-bed --out $prefix");
-    plink("--bfile $prefix --recode ped -out $prefix");
+    plink("--bfile $prefix --recode ped --out $prefix");
     return;
 }
 
@@ -1166,7 +1169,8 @@ sub usage {
     print " -e n_pc: number of eigenvectors to keep from smartpca\n";
     print " -m MAF: Minor Allele Frequency\n";
     print " -x missing: maximum per-SNP missing\n";
-    print " -z F: remove samples with heterozygosity < F coeficient\n";
+    print " -z F: remove samples with F inbreeding coefficient below F (suggested: 0.999\n";
+    print "        for highly inbred lines; use lower values e.g. 0.5 for landraces)\n";
     print "\n";
     print "Further details and examples are given in the documentation\n";
     exit -1;

--- a/bin/pique-input
+++ b/bin/pique-input
@@ -272,6 +272,13 @@ sub options {
     if ( $opt_i eq $opt_o ) {
         error_exit("input prefix same as output prefix");
     }
+
+    # validate F coefficient threshold
+    if ( defined $opt_z ) {
+        unless ( $opt_z =~ /^(?:0(?:\.\d+)?|1(?:\.0+)?)$/ && $opt_z >= 0 && $opt_z <= 1 ) {
+            error_exit("-z: F coefficient must be a number between 0 and 1");
+        }
+    }
     return;
 }
 
@@ -993,6 +1000,22 @@ sub het {
     }
     plink("--het --pedmap $prefix --out $prefix");
     run("awk 'NR > 1 && \$6 < $min {print \$1\" \"\$2}' $prefix.het > $prefix.hid");
+
+    # report accessions flagged for removal
+    open( my $hid, '<', "$prefix.hid" )
+      or error_exit("Cannot open $prefix.hid: $!");
+    my @removed = map { ( split " ", $_ )[1] } <$hid>;
+    close $hid;
+
+    if (@removed) {
+        print scalar @removed
+          . " accession(s) removed with F coefficient below $min:\n";
+        print "  " . join( "  ", @removed ) . "\n";
+    }
+    else {
+        print "No accessions removed (all have F coefficient >= $min)\n";
+    }
+
     plink("--pedmap $prefix --remove $prefix.hid --make-bed --out $prefix");
     plink("--bfile $prefix --recode ped --out $prefix");
     return;


### PR DESCRIPTION
## Summary

Code review fixes and improvements for the `-z` heterozygosity filtering option added in adbba44.

**Bug fixes**
- Missing `--` on `--out` flag in the final plink recode call inside `het()` — single dash would be parsed incorrectly by PLINK2
- PLINK2 `--het` outputs a `#FID IID ...` header line; the awk filter was writing it into the `.hid` remove-list because awk coerces the string `"F"` to 0 in a numeric comparison. Fixed with `NR > 1`.

**Validation**
- Added input validation for `-z`: value must be a number between 0 and 1. Exits with a clear error message if an invalid value is supplied.

**Reporting**
- `het()` now reports the names and total count of accessions removed after filtering. Printed regardless of verbose mode as it is key QC output. If no accessions are removed this is also reported.

**Documentation**
- `-z` usage string had reversed logic in the description and a typo (`coeficient`). Reworded to clarify that samples with F *below* the threshold are removed.
- POD expanded with a note that a threshold of 0.999 is very strict (only F = 1.0 guarantees zero heterozygous calls); users working with landrace or less inbred material should supply a lower value.
- Added caveat that `--het` is not appropriate for polyploid species (e.g. hexaploid or tetraploid wheat), where homeologous mapping inflates apparent heterozygosity and the F statistic loses its meaning.

## Test plan

- [x] Run existing `make input` to confirm no regression
- [x] Run `make input_het` with `-z 0.999` on rice dataset
- [x] Confirm `.hid` file no longer contains the header line
- [x] Confirm PLINK2 `--out` flag accepted without error
- [x] Confirm accession names and count are printed to stdout
- [x] Confirm invalid `-z` values (e.g. `-z foo`, `-z 1.5`, `-z -0.1`) exit with a clear error